### PR TITLE
Adiciona estrutura de rotas, middleware e cache para API's

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,10 @@
   },
   "dependencies": {
     "axios": "^1.5.0",
+    "cors": "^2.8.5",
     "eslint-config-next": "^13.4.19",
     "next": "^13.4.19",
+    "next-connect": "^1.0.0",
     "next-pwa": "^5.5.5",
     "polished": "^4.2.2",
     "react": "^18.2.0",
@@ -52,6 +54,7 @@
     "@testing-library/cypress": "^9.0.0",
     "@testing-library/jest-dom": "^6.1.2",
     "@testing-library/react": "^14.0.0",
+    "@types/cors": "^2.8.13",
     "@types/jest": "^27.5.0",
     "@types/node": "^20.5.7",
     "@types/react": "^18.2.21",

--- a/src/errors/BadRequestError.ts
+++ b/src/errors/BadRequestError.ts
@@ -1,0 +1,18 @@
+import BaseError, { ErrorType } from './BaseError';
+
+export default class BadRequestError extends BaseError {
+  constructor({
+    status = 400,
+    message,
+    name = 'BadRequestError',
+    type = 'bad_request',
+    errors = []
+  }: ErrorType) {
+    super({ message });
+
+    this.name = name;
+    this.status = status;
+    this.type = type;
+    this.errors = errors;
+  }
+}

--- a/src/errors/BaseError.ts
+++ b/src/errors/BaseError.ts
@@ -1,0 +1,31 @@
+export interface ErrorType {
+  status?: number;
+  name?: string;
+  type?: string;
+  message?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  errors?: any[]; // eslint-disable-line @typescript-eslint/no-explicit-any
+  stack?: string;
+}
+
+export default class BaseError extends Error {
+  status: number;
+  type: string;
+  errors: any[]; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+  constructor({
+    status = 500,
+    name = 'BaseError',
+    message,
+    type = 'base_error',
+    errors = [],
+    stack = ''
+  }: ErrorType) {
+    super(message);
+
+    this.stack = stack;
+    this.name = name;
+    this.status = status;
+    this.type = type;
+    this.errors = errors;
+  }
+}

--- a/src/errors/InternalError.ts
+++ b/src/errors/InternalError.ts
@@ -1,0 +1,18 @@
+import BaseError, { ErrorType } from './BaseError';
+
+export default class InternalError extends BaseError {
+  constructor({
+    status = 500,
+    name = 'InternalError',
+    message,
+    type = 'internal',
+    errors = []
+  }: ErrorType) {
+    super({ message });
+
+    this.name = name;
+    this.status = status;
+    this.type = type;
+    this.errors = errors;
+  }
+}

--- a/src/errors/NotFoundError.ts
+++ b/src/errors/NotFoundError.ts
@@ -1,0 +1,18 @@
+import BaseError, { ErrorType } from './BaseError';
+
+export default class NotFoundError extends BaseError {
+  constructor({
+    status = 404,
+    name = 'NotFoundError',
+    message,
+    type = 'not_found',
+    errors = []
+  }: ErrorType) {
+    super({ message });
+
+    this.name = name;
+    this.status = status;
+    this.type = type;
+    this.errors = errors;
+  }
+}

--- a/src/middlewares/api.middleware.ts
+++ b/src/middlewares/api.middleware.ts
@@ -1,0 +1,53 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createRouter } from 'next-connect';
+
+import cors from 'cors';
+import cache from 'middlewares/cache.middleware';
+import onError from 'middlewares/errorHandler.middleware';
+import logger from 'middlewares/logger.middleware';
+
+const corsDefaultConfiguration = {
+  origin: '*',
+  methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
+  preflightContinue: false,
+  optionsSuccessStatus: 204
+};
+
+const cacheDefaultConfiguration = 86400;
+
+const onNoMatch = (request: NextApiRequest, response: NextApiResponse) => {
+  return response.status(404).json({
+    message: 'Page not found.',
+    type: 'not_found',
+    name: 'NotFoundError'
+  });
+};
+
+export const handler = {
+  onError,
+  onNoMatch
+};
+
+export default (
+  options: {
+    cors?: cors.CorsOptions;
+    cache?: number;
+  } = {}
+) => {
+  const corsOptions = options.cors || {};
+  const cacheOptions = options.cache || cacheDefaultConfiguration;
+
+  const configurations = {
+    cors: {
+      ...corsDefaultConfiguration,
+      ...corsOptions
+    },
+    cache: cacheOptions
+  };
+
+  const nc = createRouter<NextApiRequest, NextApiResponse>();
+  return nc
+    .use(cors(configurations.cors))
+    .use(logger)
+    .use(cache(configurations.cache));
+};

--- a/src/middlewares/cache.middleware.ts
+++ b/src/middlewares/cache.middleware.ts
@@ -1,0 +1,26 @@
+// max-age especifica quanto tempo o browser deve manter o valor em cache, em segundos.
+// s-maxage é uma header lida pelo servidor proxy (neste caso, Vercel).
+// stale-while-revalidate indica que o conteúdo da cache pode ser servido como "stale" e revalidado no background
+//
+// Por que os valores abaixo?
+//
+// 1. O cache da Now é muito rápido e permite respostas em cerca de 10ms. O valor de
+//    um dia (86400 segundos) é suficiente para garantir performance e também que as
+//    respostas estejam relativamente sincronizadas caso o governo decida atualizar os CEPs.
+// 2. O cache da Now é invalidado toda vez que um novo deploy é feito, garantindo que
+//    todas as novas requisições sejam servidas pela implementação mais recente da API.
+// 3. Não há browser caching pois este tipo de API normalmente é utilizada uma vez só
+//    por um usuário. Se fizessemos caching, os valores ficariam lá guardados no browser
+//    sem necessidade, só ocupando espaço em disco. A história seria diferente se a API
+//    servisse fotos dos usuários, por exemplo. Além disso teríamos problemas com
+//    stale/out-of-date cache caso alterássemos a implementação da API.
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default (time: number) =>
+  (request: NextApiRequest, response: NextApiResponse, next: () => void) => {
+    const CACHE_CONTROL_HEADER_VALUE = `max-age=0, s-maxage=${time}, stale-while-revalidate, public`;
+
+    response.setHeader('Cache-Control', CACHE_CONTROL_HEADER_VALUE);
+
+    next();
+  };

--- a/src/middlewares/errorHandler.middleware.ts
+++ b/src/middlewares/errorHandler.middleware.ts
@@ -1,0 +1,31 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+import BaseError from 'errors/BaseError';
+
+export default function errorHandler(
+  error: any, // eslint-disable-line @typescript-eslint/no-explicit-any
+  request: NextApiRequest,
+  response: NextApiResponse
+) {
+  console.log({
+    url: request.url,
+    ...error
+  });
+
+  if (error instanceof BaseError) {
+    const errorResponse = {
+      message: error.message,
+      type: error.type,
+      name: error.name,
+      errors: error.errors
+    };
+
+    if (error.errors.length !== 0) {
+      errorResponse.errors = error.errors;
+    }
+
+    return response.status(error.status).json(errorResponse);
+  }
+
+  return response.status(500).json(error);
+}

--- a/src/middlewares/logger.middleware.ts
+++ b/src/middlewares/logger.middleware.ts
@@ -1,0 +1,17 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default function logger(
+  request: NextApiRequest,
+  response: NextApiResponse,
+  next: () => void
+) {
+  const clientIp =
+    request.headers['x-forwarded-for'] || request.socket.remoteAddress;
+
+  console.log({
+    url: request.url,
+    clientIp
+  });
+
+  return next();
+}

--- a/src/pages/api/hello.ts
+++ b/src/pages/api/hello.ts
@@ -1,0 +1,16 @@
+import { NextApiRequest, NextApiResponse } from 'next/types';
+
+import app, { handler } from 'middlewares/api.middleware';
+
+async function get(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    res.status(200).json({
+      message: 'Hello World'
+    });
+  } catch (error: unknown) {
+    console.log(error);
+    res.status(400).json({ error: error });
+  }
+}
+
+export default app().get(get).handler(handler);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4046,6 +4046,11 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@tsconfig/node16@^1.0.3":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
+  integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
+
 "@types/aria-query@^5.0.1":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.1.tgz#3286741fb8f1e1580ac28784add4c7a1d49bdfbc"
@@ -4108,6 +4113,13 @@
   version "3.4.35"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.35.tgz#5fcf6ae445e4021d1fc2219a4873cc73a3bb2ad1"
   integrity sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==
+  dependencies:
+    "@types/node" "*"
+
+"@types/cors@^2.8.13":
+  version "2.8.13"
+  resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.13.tgz#b8ade22ba455a1b8cb3b5d3f35910fd204f84f94"
+  integrity sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==
   dependencies:
     "@types/node" "*"
 
@@ -6789,6 +6801,14 @@ core-util-is@~1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
+
+cors@^2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
 
 cosmiconfig@^6.0.0:
   version "6.0.0"
@@ -11836,6 +11856,14 @@ nested-error-stacks@^2.0.0, nested-error-stacks@^2.1.0:
   resolved "https://registry.yarnpkg.com/nested-error-stacks/-/nested-error-stacks-2.1.1.tgz#26c8a3cee6cc05fbcf1e333cd2fc3e003326c0b5"
   integrity sha512-9iN1ka/9zmX1ZvLV9ewJYEk9h7RyRRtqdK0woXcqohu8EWIerfPUjYJPg0ULy0UqP7cslmdGc8xKDJcojlKiaw==
 
+next-connect@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/next-connect/-/next-connect-1.0.0.tgz#49361a92b2d22db1cce73f94dfe793cd4b9e0106"
+  integrity sha512-FeLURm9MdvzY1SDUGE74tk66mukSqL6MAzxajW7Gqh6DZKBZLrXmXnGWtHJZXkfvoi+V/DUe9Hhtfkl4+nTlYA==
+  dependencies:
+    "@tsconfig/node16" "^1.0.3"
+    regexparam "^2.0.1"
+
 next-pwa@^5.5.5:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/next-pwa/-/next-pwa-5.6.0.tgz#f7b1960c4fdd7be4253eb9b41b612ac773392bf4"
@@ -12037,7 +12065,7 @@ nwsapi@^2.2.0:
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.2.tgz#e5418863e7905df67d51ec95938d67bf801f0bb0"
   integrity sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==
 
-object-assign@^4.0.1, object-assign@^4.1.1:
+object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
@@ -13451,6 +13479,11 @@ regexp.prototype.flags@^1.5.0:
     call-bind "^1.0.2"
     define-properties "^1.2.0"
     functions-have-names "^1.2.3"
+
+regexparam@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/regexparam/-/regexparam-2.0.1.tgz#c912f5dae371e3798100b3c9ce22b7414d0889fa"
+  integrity sha512-zRgSaYemnNYxUv+/5SeoHI0eJIgTL/A2pUtXUPLHQxUldagouJ9p+K6IbIZ/JiQuCEv2E2B1O11SjVQy3aMCkw==
 
 regexpu-core@^5.2.1:
   version "5.2.2"
@@ -15606,7 +15639,7 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vary@~1.1.2:
+vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==


### PR DESCRIPTION
Um dos pontos altos do nextjs é poder utilizar do SSR para realizar requisições no back-end onerando menos o usuário, com isso há a possibilidade de criação de monolitos, BFF's (back-end-from-front-end) ou até mesmo only APIs usando o nextjs (como o case [BrasilAPI](https://github.com/BrasilAPI/BrasilAPI)). Inspirado na própria arquitetura e robustês do Brasil API, proponho a implementação de recursos para facilitar e empoderar a utilização de API dentro do nextjs. 
Lembrando que o recurso de Cache apresentado aqui, que também é utilizado no BrasilAPI, é extremamente poderoso e funcional quando utilizado em projetos NextJs + Vercel. 

Favor verificar se a disposição dos ficheiros e arquivos criados condizem com a proposta de organização do projeto. 